### PR TITLE
Ironic rebalance (victoria)

### DIFF
--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -9898,6 +9898,8 @@ class ComputeManager(manager.Manager):
                                                             use_slave=True,
                                                             startup=startup)
 
+        self.rt.clean_compute_node_cache(compute_nodes_in_db)
+
         # Delete orphan compute node not reported by driver but still in db
         for cn in compute_nodes_in_db:
             if cn.hypervisor_hostname not in nodenames:

--- a/nova/compute/manager.py
+++ b/nova/compute/manager.py
@@ -9908,17 +9908,30 @@ class ComputeManager(manager.Manager):
                          "nodes are %(nodes)s",
                          {'id': cn.id, 'hh': cn.hypervisor_hostname,
                           'nodes': nodenames})
-                cn.destroy()
-                self.rt.remove_node(cn.hypervisor_hostname)
-                # Delete the corresponding resource provider in placement,
-                # along with any associated allocations.
                 try:
-                    self.reportclient.delete_resource_provider(context, cn,
-                                                               cascade=True)
-                except keystone_exception.ClientException as e:
-                    LOG.error(
-                        "Failed to delete compute node resource provider "
-                        "for compute node %s: %s", cn.uuid, six.text_type(e))
+                    cn.destroy()
+                except exception.ComputeHostNotFound:
+                    # NOTE(mgoddard): it's possible that another compute
+                    # service took ownership of this compute node since we
+                    # queried it due to a rebalance, and this will cause the
+                    # deletion to fail. Ignore the error in that case.
+                    LOG.info("Ignoring failure to delete orphan compute node "
+                             "%(id)s on hypervisor host %(hh)s due to "
+                             "possible node rebalance",
+                             {'id': cn.id, 'hh': cn.hypervisor_hostname})
+                    self.rt.remove_node(cn.hypervisor_hostname)
+                    self.reportclient.invalidate_resource_provider(cn.uuid)
+                else:
+                    self.rt.remove_node(cn.hypervisor_hostname)
+                    # Delete the corresponding resource provider in placement,
+                    # along with any associated allocations.
+                    try:
+                        self.reportclient.delete_resource_provider(
+                            context, cn, cascade=True)
+                    except keystone_exception.ClientException as e:
+                        LOG.error(
+                            "Failed to delete compute node resource provider "
+                            "for compute node %s: %s", cn.uuid, str(e))
 
         for nodename in nodenames:
             self._update_available_resource_for_node(context, nodename,

--- a/nova/compute/resource_tracker.py
+++ b/nova/compute/resource_tracker.py
@@ -2005,3 +2005,4 @@ class ResourceTracker(object):
             # where another compute service took ownership of the node. Clean
             # up the cache.
             self.remove_node(stale_cn)
+            self.reportclient.invalidate_resource_provider(stale_cn)

--- a/nova/compute/resource_tracker.py
+++ b/nova/compute/resource_tracker.py
@@ -1988,3 +1988,20 @@ class ResourceTracker(object):
         if migration:
             migration.status = 'done'
             migration.save()
+
+    @utils.synchronized(COMPUTE_RESOURCE_SEMAPHORE, fair=True)
+    def clean_compute_node_cache(self, compute_nodes_in_db):
+        """Clean the compute node cache of any nodes that no longer exist.
+
+        :param compute_nodes_in_db: list of ComputeNode objects from the DB.
+        """
+        compute_nodes_in_db_nodenames = {cn.hypervisor_hostname
+                                         for cn in compute_nodes_in_db}
+        stale_cns = set(self.compute_nodes) - compute_nodes_in_db_nodenames
+
+        for stale_cn in stale_cns:
+            # NOTE(mgoddard): we have found a node in the cache that has no
+            # compute node in the DB. This could be due to a node rebalance
+            # where another compute service took ownership of the node. Clean
+            # up the cache.
+            self.remove_node(stale_cn)

--- a/nova/db/api.py
+++ b/nova/db/api.py
@@ -344,15 +344,16 @@ def compute_node_update(context, compute_id, values):
     return IMPL.compute_node_update(context, compute_id, values)
 
 
-def compute_node_delete(context, compute_id):
+def compute_node_delete(context, compute_id, compute_host):
     """Delete a compute node from the database.
 
     :param context: The security context
     :param compute_id: ID of the compute node
+    :param compute_host: Hostname of the compute service
 
     Raises ComputeHostNotFound if compute node with the given ID doesn't exist.
     """
-    return IMPL.compute_node_delete(context, compute_id)
+    return IMPL.compute_node_delete(context, compute_id, compute_host)
 
 
 def compute_node_statistics(context):

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -690,7 +690,7 @@ def compute_node_search_by_hypervisor(context, hypervisor_match):
 
 
 @pick_context_manager_writer
-def compute_node_create(context, values):
+def _compute_node_create(context, values):
     """Creates a new ComputeNode and populates the capacity fields
     with the most recent data.
     """
@@ -698,8 +698,21 @@ def compute_node_create(context, values):
 
     compute_node_ref = models.ComputeNode()
     compute_node_ref.update(values)
+    compute_node_ref.save(context.session)
+    return compute_node_ref
+
+
+# NOTE(mgoddard): We avoid decorating this with @pick_context_manager_writer,
+# so that we get a separate transaction in the exception handler. This avoids
+# an error message about inactive DB sessions during a transaction rollback.
+# See https://bugs.launchpad.net/nova/+bug/1853159.
+def compute_node_create(context, values):
+    """Creates a new ComputeNode and populates the capacity fields
+    with the most recent data. Will restore a soft deleted compute node if a
+    UUID has been explicitly requested.
+    """
     try:
-        compute_node_ref.save(context.session)
+        compute_node_ref = _compute_node_create(context, values)
     except db_exc.DBDuplicateEntry:
         with excutils.save_and_reraise_exception(logger=LOG) as err_ctx:
             # Check to see if we have a (soft) deleted ComputeNode with the

--- a/nova/db/sqlalchemy/api.py
+++ b/nova/db/sqlalchemy/api.py
@@ -763,10 +763,10 @@ def compute_node_update(context, compute_id, values):
 
 
 @pick_context_manager_writer
-def compute_node_delete(context, compute_id):
+def compute_node_delete(context, compute_id, compute_host):
     """Delete a ComputeNode record."""
     result = model_query(context, models.ComputeNode).\
-             filter_by(id=compute_id).\
+             filter_by(id=compute_id, host=compute_host).\
              soft_delete(synchronize_session=False)
 
     if not result:

--- a/nova/objects/compute_node.py
+++ b/nova/objects/compute_node.py
@@ -360,7 +360,7 @@ class ComputeNode(base.NovaPersistentObject, base.NovaObject):
 
     @base.remotable
     def destroy(self):
-        db.compute_node_delete(self._context, self.id)
+        db.compute_node_delete(self._context, self.id, self.host)
 
     def update_from_virt_driver(self, resources):
         # NOTE(pmurray): the virt driver provides a dict of values that

--- a/nova/scheduler/client/report.py
+++ b/nova/scheduler/client/report.py
@@ -678,11 +678,7 @@ class SchedulerReportClient(object):
             if resp:
                 LOG.info("Deleted resource provider %s", rp_uuid)
             # clean the caches
-            try:
-                self._provider_tree.remove(rp_uuid)
-            except ValueError:
-                pass
-            self._association_refresh_time.pop(rp_uuid, None)
+            self.invalidate_resource_provider(rp_uuid)
             return
 
         msg = ("[%(placement_req_id)s] Failed to delete resource provider "
@@ -2180,6 +2176,17 @@ class SchedulerReportClient(object):
                 # TODO(efried): Raise these.  Right now this is being
                 #  left a no-op for backward compatibility.
                 pass
+
+    def invalidate_resource_provider(self, name_or_uuid):
+        """Invalidate the cache for a resource provider.
+
+        :param name_or_uuid: Name or UUID of the resource provider to look up.
+        """
+        try:
+            self._provider_tree.remove(name_or_uuid)
+        except ValueError:
+            pass
+        self._association_refresh_time.pop(name_or_uuid, None)
 
     def get_provider_by_name(self, context, name):
         """Queries the placement API for resource provider information matching

--- a/nova/tests/functional/regressions/test_bug_1853009.py
+++ b/nova/tests/functional/regressions/test_bug_1853009.py
@@ -153,9 +153,8 @@ class NodeRebalanceDeletedComputeNodeRaceTestCase(
         self.assertEqual(0, len(rps), rps)
 
         # host_b[3]: Should recreate compute node and resource provider.
-        # FIXME(mgoddard): Resource provider not recreated here, because it
-        # exists in the provider tree. See
-        # https://bugs.launchpad.net/nova/+bug/1841481.
+        # FIXME(mgoddard): Resource provider not recreated here, due to
+        # https://bugs.launchpad.net/nova/+bug/1853159.
         host_b.manager.update_available_resource(self.ctxt)
 
         # Verify that the node was recreated.
@@ -170,14 +169,11 @@ class NodeRebalanceDeletedComputeNodeRaceTestCase(
         self.assertEqual(0, len(rps), rps)
 
         # But the RP exists in the provider tree.
-        self.assertTrue(host_b.manager.rt.reportclient._provider_tree.exists(
+        self.assertFalse(host_b.manager.rt.reportclient._provider_tree.exists(
             self.nodename))
 
         # host_b[1]: Should add compute node to RT cache and recreate resource
         # provider.
-        # FIXME(mgoddard): Resource provider not recreated here, because it
-        # exists in the provider tree. See
-        # https://bugs.launchpad.net/nova/+bug/1841481.
         host_b.manager.update_available_resource(self.ctxt)
 
         # Verify that the node still exists.
@@ -186,13 +182,10 @@ class NodeRebalanceDeletedComputeNodeRaceTestCase(
         # And it is now in the RT cache.
         self.assertIn(self.nodename, host_b.manager.rt.compute_nodes)
 
-        # There is still no RP.
+        # The resource provider has now been created.
         rps = self._get_all_providers()
-        self.assertEqual(0, len(rps), rps)
-
-        # But the RP it exists in the provider tree.
-        self.assertTrue(host_b.manager.rt.reportclient._provider_tree.exists(
-            self.nodename))
+        self.assertEqual(1, len(rps), rps)
+        self.assertEqual(self.nodename, rps[0]['name'])
 
         # This fails due to the lack of a resource provider.
         self.assertIn(

--- a/nova/tests/functional/regressions/test_bug_1853009.py
+++ b/nova/tests/functional/regressions/test_bug_1853009.py
@@ -90,10 +90,6 @@ class NodeRebalanceDeletedComputeNodeRaceTestCase(
         # update for this node. See
         # https://bugs.launchpad.net/nova/+bug/1853159.
         host_b.manager.update_available_resource(self.ctxt)
-        self.assertIn(
-            'Deleting orphan compute node %s hypervisor host '
-            'is host_b, nodes are' % cn.id,
-            self.stdlog.logger.output)
         self._assert_hypervisor_api(self.nodename, expected_host='host_b')
         # There should only be one resource provider (fake-node).
         original_rps = self._get_all_providers()
@@ -157,27 +153,44 @@ class NodeRebalanceDeletedComputeNodeRaceTestCase(
         self.assertEqual(0, len(rps), rps)
 
         # host_b[3]: Should recreate compute node and resource provider.
-        # FIXME(mgoddard): Compute node not recreated here, because it is
-        # already in RT.compute_nodes. See
-        # https://bugs.launchpad.net/nova/+bug/1853009.
         # FIXME(mgoddard): Resource provider not recreated here, because it
         # exists in the provider tree. See
         # https://bugs.launchpad.net/nova/+bug/1841481.
         host_b.manager.update_available_resource(self.ctxt)
 
-        # Verify that the node was not recreated.
-        hypervisors = self.api.api_get(
-            '/os-hypervisors/detail').body['hypervisors']
-        self.assertEqual(0, len(hypervisors), hypervisors)
+        # Verify that the node was recreated.
+        self._assert_hypervisor_api(self.nodename, 'host_b')
 
-        # But the compute node exists in the RT.
-        self.assertIn(self.nodename, host_b.manager.rt.compute_nodes)
+        # But due to https://bugs.launchpad.net/nova/+bug/1853159 the compute
+        # node is not cached in the RT.
+        self.assertNotIn(self.nodename, host_b.manager.rt.compute_nodes)
 
         # There is no RP.
         rps = self._get_all_providers()
         self.assertEqual(0, len(rps), rps)
 
         # But the RP exists in the provider tree.
+        self.assertTrue(host_b.manager.rt.reportclient._provider_tree.exists(
+            self.nodename))
+
+        # host_b[1]: Should add compute node to RT cache and recreate resource
+        # provider.
+        # FIXME(mgoddard): Resource provider not recreated here, because it
+        # exists in the provider tree. See
+        # https://bugs.launchpad.net/nova/+bug/1841481.
+        host_b.manager.update_available_resource(self.ctxt)
+
+        # Verify that the node still exists.
+        self._assert_hypervisor_api(self.nodename, 'host_b')
+
+        # And it is now in the RT cache.
+        self.assertIn(self.nodename, host_b.manager.rt.compute_nodes)
+
+        # There is still no RP.
+        rps = self._get_all_providers()
+        self.assertEqual(0, len(rps), rps)
+
+        # But the RP it exists in the provider tree.
         self.assertTrue(host_b.manager.rt.reportclient._provider_tree.exists(
             self.nodename))
 

--- a/nova/tests/functional/regressions/test_bug_1853009.py
+++ b/nova/tests/functional/regressions/test_bug_1853009.py
@@ -1,0 +1,187 @@
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import mock
+
+from nova import context
+from nova import objects
+from nova.tests.functional import integrated_helpers
+
+
+class NodeRebalanceDeletedComputeNodeRaceTestCase(
+    integrated_helpers.ProviderUsageBaseTestCase,
+):
+    """Regression test for bug 1853009 observed in Rocky & later.
+
+    When an ironic node re-balances from one host to another, there can be a
+    race where the old host deletes the orphan compute node after the new host
+    has taken ownership of it which results in the new host failing to create
+    the compute node and resource provider because the ResourceTracker does not
+    detect a change.
+    """
+    # Make sure we're using the fake driver that has predictable uuids
+    # for each node.
+    compute_driver = 'fake.PredictableNodeUUIDDriver'
+
+    def _assert_hypervisor_api(self, nodename, expected_host):
+        # We should have one compute node shown by the API.
+        hypervisors = self.api.api_get(
+            '/os-hypervisors/detail'
+        ).body['hypervisors']
+        self.assertEqual(1, len(hypervisors), hypervisors)
+        hypervisor = hypervisors[0]
+        self.assertEqual(nodename, hypervisor['hypervisor_hostname'])
+        self.assertEqual(expected_host, hypervisor['service']['host'])
+
+    def _start_compute(self, host):
+        host = self.start_service('compute', host)
+        # Ironic compute driver has rebalances_nodes = True.
+        host.manager.driver.rebalances_nodes = True
+        return host
+
+    def setUp(self):
+        super(NodeRebalanceDeletedComputeNodeRaceTestCase, self).setUp()
+
+        self.nodename = 'fake-node'
+        self.ctxt = context.get_admin_context()
+
+    def test_node_rebalance_deleted_compute_node_race(self):
+        # Simulate a service running and then stopping. host_a runs, creates
+        # fake-node, then is stopped. The fake-node compute node is destroyed.
+        # This leaves a soft-deleted node in the DB.
+        host_a = self._start_compute('host_a')
+        host_a.manager.driver._set_nodes([self.nodename])
+        host_a.manager.update_available_resource(self.ctxt)
+        host_a.stop()
+        cn = objects.ComputeNode.get_by_host_and_nodename(
+            self.ctxt, 'host_a', self.nodename,
+        )
+        cn.destroy()
+
+        self.assertEqual(0, len(objects.ComputeNodeList.get_all(self.ctxt)))
+
+        # Now we create a new compute service to manage our node.
+        host_b = self._start_compute('host_b')
+        host_b.manager.driver._set_nodes([self.nodename])
+
+        # When start_service runs, it will create a host_b ComputeNode. We want
+        # to delete that and inject our fake node into the driver which will
+        # be re-balanced to another host later. First assert this actually
+        # exists.
+        self._assert_hypervisor_api('host_b', expected_host='host_b')
+
+        # Now run the update_available_resource periodic to register fake-node
+        # and have it managed by host_b. This will also detect the "host_b"
+        # node as orphaned and delete it along with its resource provider.
+
+        # host_b[1]: Finds no compute record in RT. Tries to create one
+        # (_init_compute_node).
+        # FIXME(mgoddard): This shows a traceback with SQL rollback due to
+        # soft-deleted node. The create seems to succeed but breaks the RT
+        # update for this node. See
+        # https://bugs.launchpad.net/nova/+bug/1853159.
+        host_b.manager.update_available_resource(self.ctxt)
+        self.assertIn(
+            'Deleting orphan compute node %s hypervisor host '
+            'is host_b, nodes are' % cn.id,
+            self.stdlog.logger.output)
+        self._assert_hypervisor_api(self.nodename, expected_host='host_b')
+        # There should only be one resource provider (fake-node).
+        original_rps = self._get_all_providers()
+        self.assertEqual(1, len(original_rps), original_rps)
+        self.assertEqual(self.nodename, original_rps[0]['name'])
+
+        # Simulate a re-balance by restarting host_a and make it manage
+        # fake-node. At this point both host_b and host_a think they own
+        # fake-node.
+        host_a = self._start_compute('host_a')
+        host_a.manager.driver._set_nodes([self.nodename])
+
+        # host_a[1]: Finds no compute record in RT, 'moves' existing node from
+        # host_b
+        host_a.manager.update_available_resource(self.ctxt)
+        # Assert that fake-node was re-balanced from host_b to host_a.
+        self.assertIn(
+            'ComputeNode fake-node moving from host_b to host_a',
+            self.stdlog.logger.output)
+        self._assert_hypervisor_api(self.nodename, expected_host='host_a')
+
+        # host_a[2]: Begins periodic update, queries compute nodes for this
+        # host, finds the fake-node.
+        cn = objects.ComputeNode.get_by_host_and_nodename(
+            self.ctxt, 'host_a', self.nodename,
+        )
+
+        # host_b[2]: Finds no compute record in RT, 'moves' existing node from
+        # host_a
+        host_b.manager.update_available_resource(self.ctxt)
+        # Assert that fake-node was re-balanced from host_a to host_b.
+        self.assertIn(
+            'ComputeNode fake-node moving from host_a to host_b',
+            self.stdlog.logger.output)
+        self._assert_hypervisor_api(self.nodename, expected_host='host_b')
+
+        # Complete rebalance, as host_a realises it does not own fake-node.
+        host_a.manager.driver._set_nodes([])
+
+        # host_a[2]: Deletes orphan compute node.
+        # Mock out the compute node query to simulate a race condition where
+        # the list includes an orphan compute node that is newly owned by
+        # host_b by the time host_a attempts to delete it.
+        # FIXME(mgoddard): Ideally host_a would not delete a node that does not
+        # belong to it. See https://bugs.launchpad.net/nova/+bug/1853009.
+        with mock.patch(
+            'nova.compute.manager.ComputeManager._get_compute_nodes_in_db'
+        ) as mock_get:
+            mock_get.return_value = [cn]
+            host_a.manager.update_available_resource(self.ctxt)
+
+        # Verify that the node was deleted.
+        self.assertIn(
+            'Deleting orphan compute node %s hypervisor host '
+            'is fake-node, nodes are' % cn.id,
+            self.stdlog.logger.output)
+        hypervisors = self.api.api_get(
+            '/os-hypervisors/detail').body['hypervisors']
+        self.assertEqual(0, len(hypervisors), hypervisors)
+        rps = self._get_all_providers()
+        self.assertEqual(0, len(rps), rps)
+
+        # host_b[3]: Should recreate compute node and resource provider.
+        # FIXME(mgoddard): Compute node not recreated here, because it is
+        # already in RT.compute_nodes. See
+        # https://bugs.launchpad.net/nova/+bug/1853009.
+        # FIXME(mgoddard): Resource provider not recreated here, because it
+        # exists in the provider tree. See
+        # https://bugs.launchpad.net/nova/+bug/1841481.
+        host_b.manager.update_available_resource(self.ctxt)
+
+        # Verify that the node was not recreated.
+        hypervisors = self.api.api_get(
+            '/os-hypervisors/detail').body['hypervisors']
+        self.assertEqual(0, len(hypervisors), hypervisors)
+
+        # But the compute node exists in the RT.
+        self.assertIn(self.nodename, host_b.manager.rt.compute_nodes)
+
+        # There is no RP.
+        rps = self._get_all_providers()
+        self.assertEqual(0, len(rps), rps)
+
+        # But the RP exists in the provider tree.
+        self.assertTrue(host_b.manager.rt.reportclient._provider_tree.exists(
+            self.nodename))
+
+        # This fails due to the lack of a resource provider.
+        self.assertIn(
+            'Skipping removal of allocations for deleted instances',
+            self.stdlog.logger.output)

--- a/nova/tests/unit/compute/test_compute.py
+++ b/nova/tests/unit/compute/test_compute.py
@@ -202,8 +202,10 @@ class BaseTestCase(test.TestCase):
                         context, objects.ComputeNode(), cn)
                     for cn in fake_compute_nodes]
 
-        def fake_compute_node_delete(context, compute_node_id):
+        def fake_compute_node_delete(context, compute_node_id,
+                                     compute_node_host):
             self.assertEqual(2, compute_node_id)
+            self.assertEqual('fake_phyp1', compute_node_host)
 
         self.stub_out(
             'nova.compute.manager.ComputeManager._get_compute_nodes_in_db',

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -411,6 +411,33 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
         update_mock.assert_not_called()
         del_rp_mock.assert_not_called()
 
+    @mock.patch.object(manager.ComputeManager,
+                       '_update_available_resource_for_node')
+    @mock.patch.object(fake_driver.FakeDriver, 'get_available_nodes')
+    @mock.patch.object(manager.ComputeManager, '_get_compute_nodes_in_db')
+    def test_update_available_resource_destroy_rebalance(
+            self, get_db_nodes, get_avail_nodes, update_mock):
+        mock_rt = self._mock_rt()
+        rc_mock = self.useFixture(fixtures.fixtures.MockPatchObject(
+            self.compute, 'reportclient')).mock
+        db_nodes = [self._make_compute_node('node1', 1)]
+        get_db_nodes.return_value = db_nodes
+        # Destroy can fail if nodes were rebalanced between getting the node
+        # list and calling destroy.
+        db_nodes[0].destroy.side_effect = exception.ComputeHostNotFound(
+            'node1')
+        get_avail_nodes.return_value = set()
+        self.compute.update_available_resource(self.context)
+        get_db_nodes.assert_called_once_with(self.context, set(),
+                                             use_slave=True, startup=False)
+        self.assertEqual(0, update_mock.call_count)
+
+        db_nodes[0].destroy.assert_called_once_with()
+        self.assertEqual(0, rc_mock.delete_resource_provider.call_count)
+        mock_rt.remove_node.assert_called_once_with('node1')
+        rc_mock.invalidate_resource_provider.assert_called_once_with(
+            db_nodes[0].uuid)
+
     @mock.patch('nova.context.get_admin_context')
     def test_pre_start_hook(self, get_admin_context):
         """Very simple test just to make sure update_available_resource is

--- a/nova/tests/unit/compute/test_compute_mgr.py
+++ b/nova/tests/unit/compute/test_compute_mgr.py
@@ -376,18 +376,20 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase,
         )
 
         # First node in set should have been removed from DB
+        # Last node in set should have been added to DB.
         for db_node in db_nodes:
             if db_node.hypervisor_hostname == 'node1':
                 db_node.destroy.assert_called_once_with()
                 rc_mock.delete_resource_provider.assert_called_once_with(
                     self.context, db_node, cascade=True)
-                mock_rt.remove_node.assert_called_once_with(
-                    'node1')
+                mock_rt.remove_node.assert_called_once_with('node1')
                 mock_log.error.assert_called_once_with(
                     "Failed to delete compute node resource provider for "
                     "compute node %s: %s", db_node.uuid, mock.ANY)
             else:
                 self.assertFalse(db_node.destroy.called)
+        self.assertEqual(1, mock_rt.remove_node.call_count)
+        mock_rt.clean_compute_node_cache.assert_called_once_with(db_nodes)
 
     @mock.patch('nova.scheduler.client.report.SchedulerReportClient.'
                 'delete_resource_provider')

--- a/nova/tests/unit/compute/test_resource_tracker.py
+++ b/nova/tests/unit/compute/test_resource_tracker.py
@@ -4227,3 +4227,20 @@ class ProviderConfigTestCases(BaseTestCase):
         mock_log.warning.assert_called_once_with(*expected_log_call)
         self.assertIn(uuids.unknown, self.rt.absent_providers)
         self.assertEqual(result, [])
+
+
+class TestCleanComputeNodeCache(BaseTestCase):
+
+    def setUp(self):
+        super(TestCleanComputeNodeCache, self).setUp()
+        self._setup_rt()
+        self.context = context.RequestContext(
+            mock.sentinel.user_id, mock.sentinel.project_id)
+
+    @mock.patch.object(resource_tracker.ResourceTracker, "remove_node")
+    def test_clean_compute_node_cache(self, mock_remove):
+        invalid_nodename = "invalid-node"
+        self.rt.compute_nodes[_NODENAME] = self.compute
+        self.rt.compute_nodes[invalid_nodename] = mock.sentinel.compute
+        self.rt.clean_compute_node_cache([self.compute])
+        mock_remove.assert_called_once_with(invalid_nodename)

--- a/nova/tests/unit/compute/test_resource_tracker.py
+++ b/nova/tests/unit/compute/test_resource_tracker.py
@@ -4242,5 +4242,9 @@ class TestCleanComputeNodeCache(BaseTestCase):
         invalid_nodename = "invalid-node"
         self.rt.compute_nodes[_NODENAME] = self.compute
         self.rt.compute_nodes[invalid_nodename] = mock.sentinel.compute
-        self.rt.clean_compute_node_cache([self.compute])
-        mock_remove.assert_called_once_with(invalid_nodename)
+        with mock.patch.object(
+            self.rt.reportclient, "invalidate_resource_provider",
+        ) as mock_invalidate:
+            self.rt.clean_compute_node_cache([self.compute])
+            mock_remove.assert_called_once_with(invalid_nodename)
+            mock_invalidate.assert_called_once_with(invalid_nodename)

--- a/nova/tests/unit/db/test_db_api.py
+++ b/nova/tests/unit/db/test_db_api.py
@@ -5283,6 +5283,20 @@ class ComputeNodeTestCase(test.TestCase, ModelsObjectComparatorMixin):
         self.assertRaises(db_exc.DBDuplicateEntry,
                           db.compute_node_create, self.ctxt, other_node)
 
+    def test_compute_node_create_duplicate_uuid(self):
+        """Tests to make sure that no exception is raised when trying to create
+        a compute node with the same host, hypervisor_hostname and uuid values
+        as another compute node that was previously soft-deleted.
+        """
+        # Prior to fixing https://bugs.launchpad.net/nova/+bug/1853159, this
+        # raised the following error:
+        # sqlalchemy.exc.InvalidRequestError: This session is in 'inactive'
+        # state, due to the SQL transaction being rolled back; no further SQL
+        # can be emitted within this transaction.
+        db.compute_node_delete(self.ctxt, self.item['id'], self.item['host'])
+        new_node = db.compute_node_create(self.ctxt, self.compute_node_dict)
+        self.assertEqual(self.item['uuid'], new_node['uuid'])
+
     def test_compute_node_get_all(self):
         nodes = db.compute_node_get_all(self.ctxt)
         self.assertEqual(1, len(nodes))

--- a/nova/tests/unit/db/test_db_api.py
+++ b/nova/tests/unit/db/test_db_api.py
@@ -5393,7 +5393,7 @@ class ComputeNodeTestCase(test.TestCase, ModelsObjectComparatorMixin):
 
             # Now delete the newly-created compute node to ensure the related
             # compute node stats are wiped in a cascaded fashion
-            db.compute_node_delete(self.ctxt, node['id'])
+            db.compute_node_delete(self.ctxt, node['id'], node['host'])
 
             # Clean up the service
             db.service_destroy(self.ctxt, service['id'])
@@ -5567,9 +5567,17 @@ class ComputeNodeTestCase(test.TestCase, ModelsObjectComparatorMixin):
 
     def test_compute_node_delete(self):
         compute_node_id = self.item['id']
-        db.compute_node_delete(self.ctxt, compute_node_id)
+        compute_node_host = self.item['host']
+        db.compute_node_delete(self.ctxt, compute_node_id, compute_node_host)
         nodes = db.compute_node_get_all(self.ctxt)
         self.assertEqual(len(nodes), 0)
+
+    def test_compute_node_delete_different_host(self):
+        compute_node_id = self.item['id']
+        compute_node_host = 'invalid-host'
+        self.assertRaises(exception.ComputeHostNotFound,
+                          db.compute_node_delete,
+                          self.ctxt, compute_node_id, compute_node_host)
 
     def test_compute_node_search_by_hypervisor(self):
         nodes_created = []

--- a/nova/tests/unit/objects/test_compute_node.py
+++ b/nova/tests/unit/objects/test_compute_node.py
@@ -414,8 +414,9 @@ class _TestComputeNodeObject(object):
     def test_destroy(self, mock_delete):
         compute = compute_node.ComputeNode(context=self.context)
         compute.id = 123
+        compute.host = 'fake'
         compute.destroy()
-        mock_delete.assert_called_once_with(self.context, 123)
+        mock_delete.assert_called_once_with(self.context, 123, 'fake')
 
     @mock.patch.object(db, 'compute_node_get_all')
     def test_get_all(self, mock_get_all):

--- a/releasenotes/notes/bug-1853009-99414e14d1491b5f.yaml
+++ b/releasenotes/notes/bug-1853009-99414e14d1491b5f.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes an issue with multiple ``nova-compute`` services used with Ironic,
+    where a rebalance operation could result in a compute node being deleted
+    from the database and not recreated. See `bug 1853009
+    <https://bugs.launchpad.net/nova/+bug/1853009>`__ for details.


### PR DESCRIPTION
Porting patches from https://github.com/stackhpc/nova/tree/jg-ironic-rebalance-ussuri to victoria. I cherry-picked these fresh from gerrit.

The only conflict was in manager.py in https://github.com/stackhpc/nova/commit/054b08e071e255dc0a7690a93ce26585a6d7eaa7