### PR TITLE
[stable-only][cve] Check VMDK create-type against an allowed list

### DIFF
--- a/nova/conf/compute.py
+++ b/nova/conf/compute.py
@@ -1008,6 +1008,15 @@ Related options:
   filtering computes based on supported image types, which is required
   to be enabled for this to take effect.
 """),
+    cfg.ListOpt('vmdk_allowed_types',
+                default=['streamOptimized', 'monolithicSparse'],
+                help="""
+A list of strings describing allowed VMDK "create-type" subformats
+that will be allowed. This is recommended to only include
+single-file-with-sparse-header variants to avoid potential host file
+exposure due to processing named extents. If this list is empty, then no
+form of VMDK image will be allowed.
+"""),
 ]
 
 interval_opts = [


### PR DESCRIPTION
Trivial conflicts on xena only in:
	nova/conf/compute.py

NOTE(sbauza): Stable policy allows us to proactively merge a backport without waiting for the parent patch to be merged (exception to rule #4 in [1]. Marking [stable-only] in order to silence nova-tox-validate-backport

[1] https://docs.openstack.org/project-team-guide/stable-branches.html#appropriate-fixes

Related-Bug: #1996188
Change-Id: I5a399f1d3d702bfb76c067893e9c924904c8c360
