### PR TITLE
[stable-only][cve] Check VMDK create-type against an allowed list

### DIFF
--- a/nova/conf/compute.py
+++ b/nova/conf/compute.py
@@ -960,6 +960,15 @@ Possible values:
   ``nova-compute`` service to fail to start, as 0 disk devices is an invalid
   configuration that would prevent instances from being able to boot.
 """),
+    cfg.ListOpt('vmdk_allowed_types',
+                default=['streamOptimized', 'monolithicSparse'],
+                help="""
+A list of strings describing allowed VMDK "create-type" subformats
+that will be allowed. This is recommended to only include
+single-file-with-sparse-header variants to avoid potential host file
+exposure due to processing named extents. If this list is empty, then no
+form of VMDK image will be allowed.
+"""),
 ]
 
 interval_opts = [

--- a/nova/tests/unit/virt/test_images.py
+++ b/nova/tests/unit/virt/test_images.py
@@ -16,6 +16,8 @@ import os
 
 import mock
 from oslo_concurrency import processutils
+from oslo_serialization import jsonutils
+from oslo_utils import imageutils
 import six
 
 from nova.compute import utils as compute_utils
@@ -136,3 +138,47 @@ class QemuTestCase(test.NoDBTestCase):
                     '-O', 'out_format', '-f', 'in_format', 'source', 'dest')
         mock_disk_op_sema.__enter__.assert_called_once()
         self.assertTupleEqual(expected, mock_execute.call_args[0])
+
+    def test_convert_image_vmdk_allowed_list_checking(self):
+        info = {'format': 'vmdk',
+                'format-specific': {
+                    'type': 'vmdk',
+                    'data': {
+                        'create-type': 'monolithicFlat',
+                }}}
+
+        # If the format is not in the allowed list, we should get an error
+        self.assertRaises(exception.ImageUnacceptable,
+                          images.check_vmdk_image, 'foo',
+                          imageutils.QemuImgInfo(jsonutils.dumps(info),
+                                                 format='json'))
+
+        # With the format in the allowed list, no error
+        self.flags(vmdk_allowed_types=['streamOptimized', 'monolithicFlat',
+                                       'monolithicSparse'],
+                   group='compute')
+        images.check_vmdk_image('foo',
+                                imageutils.QemuImgInfo(jsonutils.dumps(info),
+                                                       format='json'))
+
+        # With an empty list, allow nothing
+        self.flags(vmdk_allowed_types=[], group='compute')
+        self.assertRaises(exception.ImageUnacceptable,
+                          images.check_vmdk_image, 'foo',
+                          imageutils.QemuImgInfo(jsonutils.dumps(info),
+                                                 format='json'))
+
+    @mock.patch.object(images, 'fetch')
+    @mock.patch('nova.privsep.qemu.unprivileged_qemu_img_info')
+    def test_fetch_checks_vmdk_rules(self, mock_info, mock_fetch):
+        info = {'format': 'vmdk',
+                'format-specific': {
+                    'type': 'vmdk',
+                    'data': {
+                        'create-type': 'monolithicFlat',
+                }}}
+        mock_info.return_value = jsonutils.dumps(info)
+        with mock.patch('os.path.exists', return_value=True):
+            e = self.assertRaises(exception.ImageUnacceptable,
+                                  images.fetch_to_raw, None, 'foo', 'anypath')
+            self.assertIn('Invalid VMDK create-type specified', str(e))


### PR DESCRIPTION
NOTE(sbauza): Stable policy allows us to proactively merge a backport without waiting for the parent patch to be merged (exception to rule #4 in [1]. Marking [stable-only] in order to silence nova-tox-validate-backport

[1] https://docs.openstack.org/project-team-guide/stable-branches.html#appropriate-fixes

Conflicts vs victoria in:
	nova/conf/compute.py

Related-Bug: #1996188
Change-Id: I5a399f1d3d702bfb76c067893e9c924904c8c360 (cherry picked from commit bf8b6f698c23c631c0a71d77f2716ca292c45e74)