### PR TITLE
libvirt: Wrap un-proxied listDevices() and listAllDevices()

### DIFF
--- a/nova/virt/libvirt/host.py
+++ b/nova/virt/libvirt/host.py
@@ -1592,7 +1592,9 @@ class Host(object):
         :returns: a list of virNodeDevice instance
         """
         try:
-            return self.get_connection().listDevices(cap, flags)
+            devs = [self._wrap_libvirt_proxy(dev)
+                    for dev in self.get_connection().listDevices(cap, flags)]
+            return devs
         except libvirt.libvirtError as ex:
             error_code = ex.get_error_code()
             if error_code == libvirt.VIR_ERR_NO_SUPPORT:
@@ -1612,7 +1614,10 @@ class Host(object):
         :returns: a list of virNodeDevice xml strings.
         """
         try:
-            return self.get_connection().listAllDevices(flags) or []
+            alldevs = [
+                self._wrap_libvirt_proxy(dev)
+                for dev in self.get_connection().listAllDevices(flags)] or []
+            return alldevs
         except libvirt.libvirtError as ex:
             LOG.warning(ex)
             return []

--- a/releasenotes/notes/unproxied-libvirt-list-devices-7cd218c1a33535c9.yaml
+++ b/releasenotes/notes/unproxied-libvirt-list-devices-7cd218c1a33535c9.yaml
@@ -1,0 +1,11 @@
+fixes:
+  - |
+    `Bug #2091033`_: Fixed calls to libvirt ``listDevices()`` and
+    ``listAllDevices()`` from potentially blocking all other greenthreads
+    in ``nova-compute``. Under certain circumstances, it was possible for
+    the ``nova-compute`` service to freeze with all other greenthreads
+    blocked and unable to perform any other activities including logging.
+    This issue has been fixed by wrapping the libvirt ``listDevices()``
+    and ``listAllDevices()`` calls with ``eventlet.tpool.Proxy``.
+
+    .. _Bug #2091033: https://bugs.launchpad.net/nova/+bug/2091033


### PR DESCRIPTION
This is similar to change I668643c836d46a25df46d4c99a973af5e50a39db where the objects returned in a list from a libvirt call were not tpool.Proxy wrapped. Because the objects are not wrapped, calling methods on them such as listCaps() can block all other greenthreads and can cause nova-compute to freeze for hours in certain scenarios.

This adds the same wrapping to libvirt calls which return lists of virNodeDevice.

Closes-Bug: #2091033

Change-Id: I60d6f04d374e9ede5895a43b7a75e955b0fea3c5 (cherry picked from commit f304b9eaadfd33c7ccdd6af2f60f299c3362ba1c)